### PR TITLE
Move process-architecture check to runtime

### DIFF
--- a/DataDigger2.p
+++ b/DataDigger2.p
@@ -669,7 +669,9 @@ PROCEDURE recompileSelf :
     
     IF COMPILER:ERROR THEN
     DO:
-      ASSIGN lCompileError = TRUE.
+        /* this file doesn't need to compile/run on versions under 11.3 */
+        IF bOsFile.cFileName <> "getProcessArchitecture.p"
+            THEN ASSIGN lCompileError = TRUE.
       IF bOsFile.cFileName <> "myDataDigger.p" THEN lCoreFileError = TRUE.
     END.
   END.

--- a/DataDiggerLib.p
+++ b/DataDiggerLib.p
@@ -51,11 +51,15 @@ DEFINE TEMP-TABLE ttFont NO-UNDO
  * See for more info:
  * https://knowledgebase.progress.com/articles/Article/Windows-API-call-fails-with-error-13712-in-11-7-64-bit
  */
+&IF DEFINED(PROC-ARCH)=0
+    &THEN &SCOPED-DEFINE PROC-ARCH PROCESS-ARCHITECTURE
+&ENDIF
+
 &IF PROVERSION >= '11.3' &THEN   /* PROCESS-ARCHITECTURE function is available */
-  &IF PROCESS-ARCHITECTURE = 32 &THEN /* 32-bit pointers */
+  &IF {&PROC-ARCH} = 32 &THEN /* 32-bit pointers */
     &GLOBAL-DEFINE POINTERTYPE LONG
     &GLOBAL-DEFINE POINTERBYTES 4
-  &ELSEIF PROCESS-ARCHITECTURE = 64 &THEN /* 64-bit pointers */
+  &ELSEIF {&PROC-ARCH} = 64 &THEN /* 64-bit pointers */
     &GLOBAL-DEFINE POINTERTYPE INT64
     &GLOBAL-DEFINE POINTERBYTES 8
   &ENDIF  /* PROCESS-ARCHITECTURE */

--- a/DataDiggerLib32.p
+++ b/DataDiggerLib32.p
@@ -1,0 +1,1 @@
+{DataDiggerLib.p &PROC-ARCH=32}.

--- a/DataDiggerLib64.p
+++ b/DataDiggerLib64.p
@@ -1,0 +1,1 @@
+{DataDiggerLib.p &PROC-ARCH=64}.

--- a/getProcessArchitecture.p
+++ b/getProcessArchitecture.p
@@ -1,0 +1,2 @@
+DEFINE OUTPUT PARAMETER iProcessArchitecture AS INTEGER     NO-UNDO.
+iProcessArchitecture = PROCESS-ARCHITECTURE.


### PR DESCRIPTION
progress 12 and up don't have a 32 bit compiler (that i'm aware off), but they do have 32 bit clients. this PR moves the process-architecture check from compile time to runtime so a version compiled in 64 bit can be run on 32 bit clients.

tested and validated on version:
- 10.2B07 32-bit
- 11.7.14 32-bit
- 11.7.15 64-bit
- 12.2.12 32-bit (compiled using 12.2.10 64-bit)
- 12.2.10 64-bit